### PR TITLE
Tips config

### DIFF
--- a/config/tips-client.toml
+++ b/config/tips-client.toml
@@ -1,0 +1,7 @@
+#The amount of time to wait before cycling the displayed tip. This is in miliseconds. 1000ms = 1s
+cycleTime = 10000
+#A list of tip IDs to remove from the list. Restart is required for changes to take effect.
+removedTips = []
+#A list of tip namespaces to remove from the list. Restart is requird for changes to take effect.
+removedNamespaces = ["tips"]
+


### PR DESCRIPTION
Increases time that tips stay on screen from 5 seconds to 10 seconds. Removes default tips from Tips mod.
Forgot to include this in the base PR, my bad.